### PR TITLE
Add support for nulls in maps

### DIFF
--- a/core/src/main/java/com/workday/autoparse/json/parser/JsonParserUtils.java
+++ b/core/src/main/java/com/workday/autoparse/json/parser/JsonParserUtils.java
@@ -104,7 +104,7 @@ public class JsonParserUtils {
                 return reader.nextString();
             case NULL:
                 reader.nextNull();
-                return JSONObject.NULL;
+                return null;
             default:
                 throw new IllegalStateException("Unexpected token: " + nextToken);
         }
@@ -129,7 +129,12 @@ public class JsonParserUtils {
         reader.beginObject();
         while (reader.hasNext()) {
             try {
-                result.put(reader.nextName(), parseNextValue(reader, false));
+                String name = reader.nextName();
+                Object value = parseNextValue(reader, false);
+                if (value == null) {
+                    value = JSONObject.NULL;
+                }
+                result.put(name, value);
             } catch (JSONException e) {
                 throw new RuntimeException("This should be impossible.", e);
             }
@@ -172,7 +177,7 @@ public class JsonParserUtils {
                 reader.endObject();
             } else {
                 Object o = parseNextValue(reader, true);
-                if (o == JSONObject.NULL) {
+                if (o == null) {
                     map.put(name, null);
                     continue;
                 } else if (!valueClass.isInstance(o)) {
@@ -637,6 +642,9 @@ public class JsonParserUtils {
 
             // No matching parser has been found yet; save the current name and value to the
             // jsonObject.
+            if (value == null) {
+                value = JSONObject.NULL;
+            }
             try {
                 jsonObject.put(name, value);
             } catch (JSONException e) {

--- a/core/src/main/java/com/workday/autoparse/json/parser/JsonParserUtils.java
+++ b/core/src/main/java/com/workday/autoparse/json/parser/JsonParserUtils.java
@@ -173,11 +173,13 @@ public class JsonParserUtils {
                 reader.endObject();
             } else {
                 Object o = parseNextValue(reader, true);
-                if (!valueClass.isInstance(o)) {
+                if (o == null) {
+                    map.put(name, null);
+                    continue;
+                } else if (!valueClass.isInstance(o)) {
                     throwMapException(name, key, valueClass, o);
                 }
                 value = cast(o);
-
             }
             map.put(name, value);
         }

--- a/core/src/main/java/com/workday/autoparse/json/parser/JsonParserUtils.java
+++ b/core/src/main/java/com/workday/autoparse/json/parser/JsonParserUtils.java
@@ -104,8 +104,7 @@ public class JsonParserUtils {
                 return reader.nextString();
             case NULL:
                 reader.nextNull();
-                return null;
-
+                return JSONObject.NULL;
             default:
                 throw new IllegalStateException("Unexpected token: " + nextToken);
         }
@@ -173,7 +172,7 @@ public class JsonParserUtils {
                 reader.endObject();
             } else {
                 Object o = parseNextValue(reader, true);
-                if (o == null) {
+                if (o == JSONObject.NULL) {
                     map.put(name, null);
                     continue;
                 } else if (!valueClass.isInstance(o)) {

--- a/core/src/main/java/com/workday/autoparse/json/parser/JsonParserUtils.java
+++ b/core/src/main/java/com/workday/autoparse/json/parser/JsonParserUtils.java
@@ -289,6 +289,9 @@ public class JsonParserUtils {
                                            parserTable);
             } else if (valueClass.isInstance(o)) {
                 result = cast(o);
+            } else if (o == JSONObject.NULL) {
+                map.put(name, null);
+                continue;
             }
 
             if (result != null) {

--- a/demo/src/main/java/com/workday/autoparse/json/demo/TestObject.java
+++ b/demo/src/main/java/com/workday/autoparse/json/demo/TestObject.java
@@ -162,6 +162,7 @@ public class TestObject extends AbstractTestObject {
     @JsonValue("myEmptyCollection")
     public Collection<String> myEmptyCollection;
 
+    //Nulls
     @JsonValue("myNullInt")
     public int myNullInt = 1;
 
@@ -179,6 +180,13 @@ public class TestObject extends AbstractTestObject {
     public Collection<String> myCollectionWithSingleNullValue;
     @JsonValue("myCollectionWithNullValues")
     public Collection<String> myCollectionWithNullValues;
+
+    @JsonValue("myStringMapWithSingleNullValue")
+    public Map<String, String> myStringMapWithSingleNullValue;
+    @JsonValue("myStringMapWithNullValues")
+    public Map<String, String> myStringMapWithNullValues;
+    @JsonValue("myObjectMapWithNullValues")
+    public Map<String, String> myObjectMapWithNullValues;
 
     // Fields for setters
     public String stringFromSetter;

--- a/demo/src/main/java/com/workday/autoparse/json/demo/TestObject.java
+++ b/demo/src/main/java/com/workday/autoparse/json/demo/TestObject.java
@@ -186,7 +186,7 @@ public class TestObject extends AbstractTestObject {
     @JsonValue("myStringMapWithNullValues")
     public Map<String, String> myStringMapWithNullValues;
     @JsonValue("myObjectMapWithNullValues")
-    public Map<String, String> myObjectMapWithNullValues;
+    public Map<String, SimpleTestObject> myObjectMapWithNullValues;
 
     // Fields for setters
     public String stringFromSetter;

--- a/demo/src/test/java/com/workday/autoparse/json/demo/InstanceUpdaterTest.java
+++ b/demo/src/test/java/com/workday/autoparse/json/demo/InstanceUpdaterTest.java
@@ -361,7 +361,8 @@ public class InstanceUpdaterTest {
 
         TestObject$$JsonObjectParser.INSTANCE.updateInstanceFromMap(testObject, updates, CONTEXT);
 
-        assertEquals(testObject.myCollectionWithNullValues, CollectionUtils.newArrayList("one", null, "null"));
+        assertEquals("testObject.myCollectionWithNullValues", testObject.myCollectionWithNullValues,
+                     CollectionUtils.newArrayList("one", null, "null"));
     }
 
     @Test(expected = RuntimeException.class)

--- a/demo/src/test/java/com/workday/autoparse/json/demo/JsonParserTest.java
+++ b/demo/src/test/java/com/workday/autoparse/json/demo/JsonParserTest.java
@@ -67,6 +67,27 @@ public class JsonParserTest {
         testParse("partially-delayed-object.json");
     }
 
+    @Test
+    public void testFullDelayNullMap() throws Exception {
+        TestObject testObject = (TestObject) parser.parseJsonStream(getInputStream("null-in-maps.json"));
+
+        assertNotNull("testObject.myStringMapWithSingleNullValue", testObject.myStringMapWithSingleNullValue);
+        assertEquals("testObject.myStringMapWithSingleNullValue.size", 1, testObject.myStringMapWithSingleNullValue.size());
+        assertEquals("testObject.myStringMapWithSingleNullValue[key1]", null, testObject.myStringMapWithSingleNullValue.get("key1"));
+
+        assertNotNull("testObject.myStringMapWithNullValues", testObject.myStringMapWithNullValues);
+        assertEquals("testObject.myStringMapWithNullValues.size", 3, testObject.myStringMapWithNullValues.size());
+        assertEquals("testObject.myStringMapWithNullValues[key1]", null, testObject.myStringMapWithNullValues.get("key1"));
+        assertEquals("testObject.myStringMapWithNullValues[key2]", "value2", testObject.myStringMapWithNullValues.get("key2"));
+        assertEquals("testObject.myStringMapWithNullValues[key3]", "null", testObject.myStringMapWithNullValues.get("key3"));
+
+        assertNotNull("testObject.myObjectMapWithNullValues", testObject.myObjectMapWithNullValues);
+        assertEquals("testObject.myObjectMapWithNullValues.size", 3, testObject.myObjectMapWithNullValues.size());
+        assertEquals("testObject.myObjectMapWithNullValues[key1]", new SimpleTestObject(null), testObject.myObjectMapWithNullValues.get("key1"));
+        assertEquals("testObject.myObjectMapWithNullValues[key2]", new SimpleTestObject("post-parse:value2"), testObject.myObjectMapWithNullValues.get("key2"));
+        assertEquals("testObject.myObjectMapWithNullValues[key3]", new SimpleTestObject("post-parse:null"), testObject.myObjectMapWithNullValues.get("key3"));
+    }
+
     private void testParse(String fileName) throws Exception {
         TestObject testObject = (TestObject) parser.parseJsonStream(getInputStream(fileName));
         assertNotNull("testObject", testObject);
@@ -256,29 +277,22 @@ public class JsonParserTest {
         assertEquals("testObject.myDefaultCollection", Collections.singleton("the one"),
                      testObject.myDefaultCollection);
 
-        Collection<String> expected = new ArrayList<>();
-        expected.add(null);
-        assertEquals("testObject.myCollectionWithSingleNullValue", expected, testObject.myCollectionWithSingleNullValue);
+        assertEquals("testObject.myCollectionWithSingleNullValue", CollectionUtils.newArrayList((String) null), testObject.myCollectionWithSingleNullValue);
         assertEquals("testObject.myCollectionWithNullValues",
                      CollectionUtils.newArrayList(null, "string", null, "null"), testObject.myCollectionWithNullValues);
-    }
-
-    @Test
-    public void testNullValueInMap() throws Exception {
-        TestObject testObject = (TestObject) parser.parseJsonStream(getInputStream("single-object.json"));
 
         assertNotNull("testObject.myStringMapWithSingleNullValue", testObject.myStringMapWithSingleNullValue);
         assertEquals("testObject.myStringMapWithSingleNullValue.size", 1, testObject.myStringMapWithSingleNullValue.size());
         assertEquals("testObject.myStringMapWithSingleNullValue[key1]", null, testObject.myStringMapWithSingleNullValue.get("key1"));
 
         assertNotNull("testObject.myStringMapWithNullValues", testObject.myStringMapWithNullValues);
-        assertEquals("testObject.myStringMapWithNullValues.size", 1, testObject.myStringMapWithNullValues.size());
+        assertEquals("testObject.myStringMapWithNullValues.size", 3, testObject.myStringMapWithNullValues.size());
         assertEquals("testObject.myStringMapWithNullValues[key1]", null, testObject.myStringMapWithNullValues.get("key1"));
-        assertEquals("testObject.myStringMapWithNullValues[key2]", "value2", testObject.myStringMapWithNullValues.get("key1"));
-        assertEquals("testObject.myStringMapWithNullValues[key3]", "null", testObject.myStringMapWithNullValues.get("key1"));
+        assertEquals("testObject.myStringMapWithNullValues[key2]", "value2", testObject.myStringMapWithNullValues.get("key2"));
+        assertEquals("testObject.myStringMapWithNullValues[key3]", "null", testObject.myStringMapWithNullValues.get("key3"));
 
         assertNotNull("testObject.myObjectMapWithNullValues", testObject.myObjectMapWithNullValues);
-        assertEquals("testObject.myObjectMapWithNullValues.size", 1, testObject.myObjectMapWithNullValues.size());
+        assertEquals("testObject.myObjectMapWithNullValues.size", 3, testObject.myObjectMapWithNullValues.size());
         assertEquals("testObject.myObjectMapWithNullValues[key1]", new SimpleTestObject(null), testObject.myObjectMapWithNullValues.get("key1"));
         assertEquals("testObject.myObjectMapWithNullValues[key2]", new SimpleTestObject("post-parse:value2"), testObject.myObjectMapWithNullValues.get("key2"));
         assertEquals("testObject.myObjectMapWithNullValues[key3]", new SimpleTestObject("post-parse:null"), testObject.myObjectMapWithNullValues.get("key3"));

--- a/demo/src/test/java/com/workday/autoparse/json/demo/JsonParserTest.java
+++ b/demo/src/test/java/com/workday/autoparse/json/demo/JsonParserTest.java
@@ -258,8 +258,30 @@ public class JsonParserTest {
 
         Collection<String> expected = new ArrayList<>();
         expected.add(null);
-        assertEquals(expected, testObject.myCollectionWithSingleNullValue);
-        assertEquals(CollectionUtils.newArrayList(null, "string", null, "null"), testObject.myCollectionWithNullValues);
+        assertEquals("testObject.myCollectionWithSingleNullValue", expected, testObject.myCollectionWithSingleNullValue);
+        assertEquals("testObject.myCollectionWithNullValues",
+                     CollectionUtils.newArrayList(null, "string", null, "null"), testObject.myCollectionWithNullValues);
+    }
+
+    @Test
+    public void testNullValueInMap() throws Exception {
+        TestObject testObject = (TestObject) parser.parseJsonStream(getInputStream("single-object.json"));
+
+        assertNotNull("testObject.myStringMapWithSingleNullValue", testObject.myStringMapWithSingleNullValue);
+        assertEquals("testObject.myStringMapWithSingleNullValue.size", 1, testObject.myStringMapWithSingleNullValue.size());
+        assertEquals("testObject.myStringMapWithSingleNullValue[key1]", null, testObject.myStringMapWithSingleNullValue.get("key1"));
+
+        assertNotNull("testObject.myStringMapWithNullValues", testObject.myStringMapWithNullValues);
+        assertEquals("testObject.myStringMapWithNullValues.size", 1, testObject.myStringMapWithNullValues.size());
+        assertEquals("testObject.myStringMapWithNullValues[key1]", null, testObject.myStringMapWithNullValues.get("key1"));
+        assertEquals("testObject.myStringMapWithNullValues[key2]", "value2", testObject.myStringMapWithNullValues.get("key1"));
+        assertEquals("testObject.myStringMapWithNullValues[key3]", "null", testObject.myStringMapWithNullValues.get("key1"));
+
+        assertNotNull("testObject.myObjectMapWithNullValues", testObject.myObjectMapWithNullValues);
+        assertEquals("testObject.myObjectMapWithNullValues.size", 1, testObject.myObjectMapWithNullValues.size());
+        assertEquals("testObject.myObjectMapWithNullValues[key1]", new SimpleTestObject(null), testObject.myObjectMapWithNullValues.get("key1"));
+        assertEquals("testObject.myObjectMapWithNullValues[key2]", new SimpleTestObject("post-parse:value2"), testObject.myObjectMapWithNullValues.get("key2"));
+        assertEquals("testObject.myObjectMapWithNullValues[key3]", new SimpleTestObject("post-parse:null"), testObject.myObjectMapWithNullValues.get("key3"));
     }
 
     @Test

--- a/demo/src/test/resources/com/workday/autoparse/json/demo/delayed-object.json
+++ b/demo/src/test/resources/com/workday/autoparse/json/demo/delayed-object.json
@@ -222,5 +222,24 @@
   "myDefaultCollection": null,
   "myCollectionWithSingleNullValue": [null],
   "myCollectionWithNullValues": [null, "string", null, "null"],
+  "myStringMapWithSingleNullValue": {
+    "key1": null
+  },
+  "myStringMapWithNullValues": {
+    "key1": null,
+    "key2": "value2",
+    "key3": "null"
+  },
+  "myObjectMapWithNullValues": {
+    "key1": {
+      "myString": null
+    },
+    "key2": {
+      "myString": "value2"
+    },
+    "key3": {
+      "myString": "null"
+    }
+  },
   "object": "testObject"
 }

--- a/demo/src/test/resources/com/workday/autoparse/json/demo/null-in-maps.json
+++ b/demo/src/test/resources/com/workday/autoparse/json/demo/null-in-maps.json
@@ -1,0 +1,22 @@
+{
+  "myStringMapWithSingleNullValue": {
+    "key1": null
+  },
+  "myStringMapWithNullValues": {
+    "key1": null,
+    "key2": "value2",
+    "key3": "null"
+  },
+  "myObjectMapWithNullValues": {
+    "key1": {
+      "myString": null
+    },
+    "key2": {
+      "myString": "value2"
+    },
+    "key3": {
+      "myString": "null"
+    }
+  },
+  "object": "testObject"
+}

--- a/demo/src/test/resources/com/workday/autoparse/json/demo/partially-delayed-object.json
+++ b/demo/src/test/resources/com/workday/autoparse/json/demo/partially-delayed-object.json
@@ -222,5 +222,24 @@
   "myNullCollection": null,
   "myDefaultCollection": null,
   "myCollectionWithSingleNullValue": [null],
-  "myCollectionWithNullValues": [null, "string", null, "null"]
+  "myCollectionWithNullValues": [null, "string", null, "null"],
+  "myStringMapWithSingleNullValue": {
+    "key1": null
+  },
+  "myStringMapWithNullValues": {
+    "key1": null,
+    "key2": "value2",
+    "key3": "null"
+  },
+  "myObjectMapWithNullValues": {
+    "key1": {
+      "myString": null
+    },
+    "key2": {
+      "myString": "value2"
+    },
+    "key3": {
+      "myString": "null"
+    }
+  }
 }

--- a/demo/src/test/resources/com/workday/autoparse/json/demo/single-object.json
+++ b/demo/src/test/resources/com/workday/autoparse/json/demo/single-object.json
@@ -218,5 +218,24 @@
   "myNullCollection": null,
   "myDefaultCollection": null,
   "myCollectionWithSingleNullValue": [null],
-  "myCollectionWithNullValues": [null, "string", null, "null"]
+  "myCollectionWithNullValues": [null, "string", null, "null"],
+  "myStringMapWithSingleNullValue": {
+    "key1": null
+  },
+  "myStringMapWithNullValues": {
+    "key1": null,
+    "key2": "value2",
+    "key3": "null"
+  },
+  "myObjectMapWithNullValues": {
+    "key1": {
+      "myString": null
+    },
+    "key2": {
+      "myString": "value2"
+    },
+    "key3": {
+      "myString": "null"
+    }
+  }
 }


### PR DESCRIPTION
Putting this up to start a convo about a... bug (?) I'm noticing, not really sure. This fails to pass the delayed object check because when parsing as a JSONObject:

`"myStringMapWithSingleNullValue": {
    "key1": null
  },`

Once the parser reaches the `{`, the next call to `JsonReader`'s peek method returns JsonToken.NULL. So we end up with a completely empty map. @ndtaylor is that expected? Is "key1" not a token?